### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2024-09-19
+
+The project was renamed to `jutella`.
+
+### Changed
+
+- Use "mini" model by default
+- Improve docs
+- Rename `unspoken` -> `jutella`
+
 ## [0.1.1] - 2024-09-18
 
 Improved documentation and README.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,7 +275,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jutella"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "jutella"
 description = "Chatbot API client library and CLI interface."
 license = "MIT"
 repository = "https://github.com/dmitry-markin/jutella"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## [0.2.0] - 2024-09-19

The project was renamed to `jutella`.

### Changed

- Use "mini" model by default
- Improve docs
- Rename `unspoken` -> `jutella`