### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2024-09-24
+
+This release introduces several new features and improvements. Key updates are:
+
+- Execution is now async, based on custom OpenAI API client implementation with proper error handling.
+- Added the possibility to discard old messages in the context to keep it below allowed max token limit.
+- Added support for Azure endpoints.
+- The binary dependencies made optional in the library. Use `default-features = false` when depending on the library.
+- CLI can now copy every response to clipboard via `xclip` on X11.
+
+### Added
+
+- Support Azure endpoints ([#4](https://github.com/dmitry-markin/jutella/pull/4))
+- Implement rolling context window ([#3](https://github.com/dmitry-markin/jutella/pull/3))
+- cli: Support copying every response to clipboard with `xclip` ([commit](https://github.com/dmitry-markin/jutella/commit/88e5ea633fca541edd140cd5c9c2941d8e2862ed))
+
+### Changed
+
+- Replace `openai_api_rust` with custom async OpenAI API client ([#2](https://github.com/dmitry-markin/jutella/pull/2))
+- cli: Print `xclip` stderr on invocation failure ([commit](https://github.com/dmitry-markin/jutella/commit/06f5431a2f9fca4ca0babab24a37b9644f3e82c4))
+- Make bin dependencies optional for lib ([commit](https://github.com/dmitry-markin/jutella/commit/ff76ba787df8739930cab43759c8903c48b326da))
+
 ## [0.2.0] - 2024-09-19
 
 The project was renamed to `jutella`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "jutella"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "jutella"
 description = "Chatbot API client library and CLI interface."
 license = "MIT"
 repository = "https://github.com/dmitry-markin/jutella"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ To get started with CLI, put your API key and endpoint into `~/.config/jutella.t
 
 ![Screenshot](doc/screenshot.png)
 
+Invoking the CLI with `jutella -x` makes it copy every response to cliipboard on X11.
+
+### Installation
+
+1. Install `cargo` from https://rustup.rs/.
+2. Install the CLI from [crates.io](https://crates.io/crates/jutella) with `cargo install jutella`.
+3. Alternatively, clone the repo and build the CLI with `cargo build --release`. The resulting executable will be `target/release/jutella`.
+
 
 ## Library
 

--- a/src/chat_client/openai_api/chat_completions.rs
+++ b/src/chat_client/openai_api/chat_completions.rs
@@ -33,7 +33,7 @@ use std::collections::HashMap;
 /// See https://platform.openai.com/docs/api-reference/chat/create.
 ///
 /// JSON example:
-/// ```
+/// ```json
 /// {
 ///   "model": "gpt-4o",
 ///   "messages": [
@@ -231,7 +231,7 @@ pub struct ChatCompletionsBody {
 /// See https://platform.openai.com/docs/api-reference/chat/object.
 ///
 /// JSON example:
-/// ```
+/// ```json
 /// {
 ///   "id": "chatcmpl-123",
 ///   "object": "chat.completion",


### PR DESCRIPTION
## [0.3.0] - 2024-09-24

This release introduces several new features and improvements. Key updates are:

- Execution is now async, based on custom OpenAI API client implementation with proper error handling.
- Added the possibility to discard old messages in the context to keep it below allowed max token limit.
- Added support for Azure endpoints.
- The binary dependencies made optional in the library. Use `default-features = false` when depending on the library.
- CLI can now copy every response to clipboard via `xclip` on X11.

### Added

- Support Azure endpoints ([#4](https://github.com/dmitry-markin/jutella/pull/4))
- Implement rolling context window ([#3](https://github.com/dmitry-markin/jutella/pull/3))
- cli: Support copying every response to clipboard with `xclip` ([commit](https://github.com/dmitry-markin/jutella/commit/88e5ea633fca541edd140cd5c9c2941d8e2862ed))

### Changed

- Replace `openai_api_rust` with custom async OpenAI API client ([#2](https://github.com/dmitry-markin/jutella/pull/2))
- cli: Print `xclip` stderr on invocation failure ([commit](https://github.com/dmitry-markin/jutella/commit/06f5431a2f9fca4ca0babab24a37b9644f3e82c4))
- Make bin dependencies optional for lib ([commit](https://github.com/dmitry-markin/jutella/commit/ff76ba787df8739930cab43759c8903c48b326da))