### PR TITLE
Add `min_history_tokens` rolling context window strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,6 +678,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "iter_accumulate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a515cd05da70a980cffd5965781d5ac179685c1441ead71577b9ee2d9e05b9"
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,6 +715,7 @@ dependencies = [
  "clap",
  "colored",
  "dirs",
+ "iter_accumulate",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = { version = "1.0.89", optional = true }
 clap = { version = "4.5.17", features = ["derive", "wrap_help"], optional = true }
 colored = { version = "2.1.0", optional = true }
 dirs = { version = "5.0.1", optional = true }
+iter_accumulate = "1.0.0"
 reqwest = { version = "0.12.7", default-features = false, features = ["gzip", "json", "hickory-dns", "http2", "rustls-tls", "zstd" ] }
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"

--- a/config/jutella.toml
+++ b/config/jutella.toml
@@ -17,6 +17,14 @@ model = "gpt-4o-mini"
 # Optional system message to initialize the model.
 system_message = "You are a helpful assistant."
 
+# Optional minimum conversation history to keep in the context.
+# The context will be truncated to keep at least `min_history_tokens`, but
+# no more than one request-reply to go above this threshold, and under
+# no circumstances more than `max_history_tokens`.
+# This way of truncation ensures that at least the latest round of messages
+# is always kept in the context (unless `max_history_tokens` kicks in).
+min_history_tokens = 1000
+
 # Optional maximum conversation history to keep in the context.
 max_history_tokens = 2500
 

--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -35,8 +35,8 @@ const DEFAULT_MODEL: &str = "gpt-4o-mini";
 #[derive(Debug, Parser)]
 #[command(version)]
 #[command(about = "Chatbot API CLI. Currently supports OpenAI chat API.", long_about = None)]
-#[command(after_help = "You can only set API key/token in config. \
-                        Command line options override the ones from config.")]
+#[command(after_help = "You can only set API key/token in the config. \
+                        Command line options override the ones in the config.")]
 pub struct Args {
     /// Base API url. Default: "https://api.openai.com/v1/".
     #[arg(short = 'u', long)]
@@ -62,6 +62,16 @@ pub struct Args {
     #[arg(short, long)]
     xclip: bool,
 
+    /// Keep at least that many tokens in the conversation context.
+    ///
+    /// The context will be truncated to keep at least `min_history_tokens`, but
+    /// no more than one request-reply to go above this threshold, and under
+    /// no circumstances more than `max_history_tokens`.
+    /// This way of truncation ensures that at least the latest round of messages
+    /// is always kept in the context (unless `max_history_tokens` kicks in).
+    #[arg(short = 'n', long)]
+    min_history_tokens: Option<usize>,
+
     /// Keep at most that many tokens in the conversation context.
     #[arg(short = 't', long)]
     max_history_tokens: Option<usize>,
@@ -81,6 +91,7 @@ struct ConfigFile {
     api_token: Option<String>,
     model: Option<String>,
     system_message: Option<String>,
+    min_history_tokens: Option<usize>,
     max_history_tokens: Option<usize>,
     xclip: Option<bool>,
 }
@@ -91,6 +102,7 @@ pub struct Configuration {
     pub auth: Auth,
     pub model: String,
     pub system_message: Option<String>,
+    pub min_history_tokens: Option<usize>,
     pub max_history_tokens: Option<usize>,
     pub xclip: bool,
 }
@@ -102,6 +114,7 @@ impl Configuration {
             api_version,
             model,
             system_message,
+            min_history_tokens,
             max_history_tokens,
             config,
             xclip,
@@ -151,6 +164,7 @@ impl Configuration {
 
         let system_message = system_message.or(config.system_message);
 
+        let min_history_tokens = min_history_tokens.or(config.min_history_tokens);
         let max_history_tokens = max_history_tokens.or(config.max_history_tokens);
 
         let xclip = if xclip {
@@ -165,6 +179,7 @@ impl Configuration {
             auth,
             model,
             system_message,
+            min_history_tokens,
             max_history_tokens,
             xclip,
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ async fn main() -> anyhow::Result<()> {
         model,
         system_message,
         xclip,
+        min_history_tokens,
         max_history_tokens,
     } = Configuration::init(Args::parse())?;
 
@@ -52,6 +53,7 @@ async fn main() -> anyhow::Result<()> {
             api_version,
             model,
             system_message,
+            min_history_tokens,
             max_history_tokens,
         },
     )


### PR DESCRIPTION
With `min_history_tokens` set, the context is truncated to keep at least that many tokens, but no more than one request-response above this threshold. This way of context truncation ensures that at least the latest round of messages is always kept.

 `max_history_tokens` has precedence over `min_history_tokens`, so the context size will never exceed `max_history_tokens`.